### PR TITLE
Fix Docker build failure when package.json missing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,13 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY package*.json ./
-RUN npm ci --only=production
+COPY package.json ./
+COPY package-lock.json* ./
+RUN if [ ! -f package.json ]; then \
+        echo >&2 "ERROR: package.json not found in the Docker build context. Ensure the build context points to the project root."; \
+        exit 1; \
+    fi \
+    && npm ci --only=production
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- copy the Node.js manifest files into the image explicitly before installing dependencies
- fail fast with a clear error when the Docker build context does not contain package.json so npm ci cannot run

## Testing
- not run (dockerfile change only)


------
https://chatgpt.com/codex/tasks/task_b_68cd9123d48483329c0d7fc708eeb3d7