### PR TITLE
Fix Docker build context paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,11 @@ Um ambiente Docker está disponível na pasta `docker/` para facilitar a criaç�
     docker compose up -d
     ```
 
+    O arquivo `docker-compose.yml` usa o repositório como contexto de build (`context: ..`).
+    Para reconstruir manualmente a imagem com o mesmo contexto, execute a partir da raiz do projeto:
+
+    ```bash
+    docker build -f docker/Dockerfile .
+    ```
+
 Os diretórios `volumes/cache` e `volumes/cachew` são montados como volumes para persistir a sessão do WhatsApp entre reinicializações do contêiner, e o `config/config.ini` é montado como somente leitura dentro da imagem.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY package.json ./
-COPY package-lock.json* ./
+COPY ./package.json ./
+COPY ./package-lock.json ./
 RUN if [ ! -f package.json ]; then \
         echo >&2 "ERROR: package.json not found in the Docker build context. Ensure the build context points to the project root."; \
         exit 1; \
@@ -30,7 +30,7 @@ COPY . .
 
 RUN mkdir -p cache/wwebjs_auth cachew/webjs_cache
 
-COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY docker/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 8081


### PR DESCRIPTION
## Summary
- update Dockerfile copy instructions to use repository-root paths so Compose and direct builds share the same context
- document how to invoke `docker build -f docker/Dockerfile .` so manual builds match the Compose configuration

## Testing
- `docker build -f docker/Dockerfile .` *(fails: docker not installed in CI container)*

------
https://chatgpt.com/codex/tasks/task_b_68cd962981b88332b66d899156b7f85f