### PR TITLE
Fix Docker build context expectations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ volumes/
 .git
 .gitignore
 Dockerfile
+!docker/docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -97,4 +97,8 @@ Um ambiente Docker está disponível na pasta `docker/` para facilitar a criaç�
     docker build -f docker/Dockerfile .
     ```
 
+    > **Observação:** execute o comando acima a partir da raiz do repositório.
+    > Construir usando a pasta `docker/` como contexto fará com que o Dockerfile
+    > não encontre o `package.json` nem o script de entrypoint.
+
 Os diretórios `volumes/cache` e `volumes/cachew` são montados como volumes para persistir a sessão do WhatsApp entre reinicializações do contêiner, e o `config/config.ini` é montado como somente leitura dentro da imagem.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,7 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-COPY ./package.json ./
-COPY ./package-lock.json ./
+COPY package.json package-lock.json* ./
 RUN if [ ! -f package.json ]; then \
         echo >&2 "ERROR: package.json not found in the Docker build context. Ensure the build context points to the project root."; \
         exit 1; \
@@ -30,8 +29,11 @@ COPY . .
 
 RUN mkdir -p cache/wwebjs_auth cachew/webjs_cache
 
-COPY docker/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN if [ ! -f docker/docker-entrypoint.sh ]; then \
+        echo >&2 "ERROR: docker/docker-entrypoint.sh not found in the Docker build context. Ensure you are building from the project root."; \
+        exit 1; \
+    fi \
+    && install -m 755 docker/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 
 EXPOSE 8081
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
## Summary
- ensure Dockerfile copies manifests and entrypoint only when the project root is the build context
- install the entrypoint from files already copied into the image and add guardrails for missing files
- document that `docker build -f docker/Dockerfile .` must be executed from the repository root and keep the entrypoint in the build context

## Testing
- not run (environment does not provide Docker)


------
https://chatgpt.com/codex/tasks/task_b_68cd9474553083328590eb0fe8cd9309