### PR TITLE
Improve Docker config bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
 
 Um ambiente Docker está disponível na pasta `docker/` para facilitar a criação de contêineres do bot.
 
-1. Crie o arquivo de configuração copiando o template:
+1. Crie (ou atualize) o arquivo de configuração copiando o template:
 
     ```bash
     mkdir -p config
@@ -79,6 +79,9 @@ Um ambiente Docker está disponível na pasta `docker/` para facilitar a criaç�
     ```
 
     Ajuste as chaves `port`, `responseUrl`, `responseHostname` e `responsePath` conforme o ambiente.
+    Caso o arquivo não seja criado, o contêiner utilizará automaticamente o `config.ini.tpl`
+    embarcado na imagem. Ainda assim, recomenda-se manter um `config/config.ini` para
+    facilitar a customização.
 
 2. Opcionalmente ajuste o identificador do bot no `docker/docker-compose.yml` alterando a variável `BOT_ID`.
 
@@ -101,4 +104,4 @@ Um ambiente Docker está disponível na pasta `docker/` para facilitar a criaç�
     > Construir usando a pasta `docker/` como contexto fará com que o Dockerfile
     > não encontre o `package.json` nem o script de entrypoint.
 
-Os diretórios `volumes/cache` e `volumes/cachew` são montados como volumes para persistir a sessão do WhatsApp entre reinicializações do contêiner, e o `config/config.ini` é montado como somente leitura dentro da imagem.
+Os diretórios `volumes/cache` e `volumes/cachew` são montados como volumes para persistir a sessão do WhatsApp entre reinicializações do contêiner, e toda a pasta `config/` é montada como somente leitura. Caso exista um `config.ini`, o entrypoint o copiará para `/app/config.ini` antes de iniciar o bot.

--- a/config/README.md
+++ b/config/README.md
@@ -7,3 +7,7 @@ cp ../config.ini.tpl config.ini
 ```
 
 Em seguida ajuste os parâmetros `port`, `responseUrl`, `responseHostname` e `responsePath` conforme o ambiente onde o contêiner será executado.
+
+> **Dica:** caso este arquivo não exista, o entrypoint do contêiner copiará automaticamente
+> o `config.ini.tpl` padrão que acompanha a imagem. Manter um `config.ini` nesta pasta,
+> entretanto, facilita a personalização das variáveis para cada instância.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,12 @@ COPY . .
 
 RUN mkdir -p cache/wwebjs_auth cachew/webjs_cache
 
+# Provide a default configuration inside the image so the container can
+# start even when a custom config.ini is not bind mounted.
+RUN if [ -f config.ini.tpl ] && [ ! -f config.ini ]; then \
+        cp config.ini.tpl config.ini; \
+    fi
+
 RUN if [ ! -f docker/docker-entrypoint.sh ]; then \
         echo >&2 "ERROR: docker/docker-entrypoint.sh not found in the Docker build context. Ensure you are building from the project root."; \
         exit 1; \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - BOT_ID=999
       - TZ=America/Sao_Paulo
     volumes:
-      - ../config/config.ini:/app/config.ini:ro
+      - ../config:/config:ro
       - ../volumes/cache:/app/cache
       - ../volumes/cachew:/app/cachew
     ports:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,6 +1,23 @@
 #!/bin/sh
 set -e
 
+CONFIG_FILE="/app/config.ini"
+CONFIG_TEMPLATE="/app/config.ini.tpl"
+MOUNTED_CONFIG="/config/config.ini"
+
+if [ -f "$MOUNTED_CONFIG" ]; then
+    echo "Loading configuration from $MOUNTED_CONFIG."
+    cp "$MOUNTED_CONFIG" "$CONFIG_FILE"
+elif [ ! -f "$CONFIG_FILE" ] && [ -f "$CONFIG_TEMPLATE" ]; then
+    echo "No external config.ini provided; using template defaults."
+    cp "$CONFIG_TEMPLATE" "$CONFIG_FILE"
+fi
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "ERROR: config.ini not found. Provide one in ../config or include it in the image." >&2
+    exit 1
+fi
+
 BOT_ID="${1:-${BOT_ID:-01}}"
 
 exec node /app/chatbot.js -b "$BOT_ID"


### PR DESCRIPTION
## Summary
- ensure the Docker image ships a default config.ini copied from the template when no bind-mounted config is provided
- update the entrypoint and docker-compose.yml to load configuration from the mounted config/ directory or fall back to the template
- refresh the documentation to explain the new configuration behaviour

## Testing
- sh -n docker/docker-entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_b_68cda082c8dc8332b34c0662eaf6f780