### PR TITLE
Implement session management API endpoints

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -4,25 +4,22 @@
  * Module dependencies.
  */
 
-var { app, lydiabot} = require('../app');
-
-global.lydiabot = lydiabot;
-
-var debug = require('debug')('lywabot:server');
-var http = require('http');
+const app = require('../app');
+const debug = require('debug')('lywabot:server');
+const http = require('http');
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+const port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
 /**
  * Create HTTP server.
  */
 
-var server = http.createServer(app);
+const server = http.createServer(app);
 
 /**
  * Listen on provided port, on all network interfaces.
@@ -37,16 +34,16 @@ server.on('listening', onListening);
  */
 
 function normalizePort(val) {
-  var port = parseInt(val, 10);
+  const portNumber = parseInt(val, 10);
 
-  if (isNaN(port)) {
+  if (Number.isNaN(portNumber)) {
     // named pipe
     return val;
   }
 
-  if (port >= 0) {
+  if (portNumber >= 0) {
     // port number
-    return port;
+    return portNumber;
   }
 
   return false;
@@ -61,18 +58,16 @@ function onError(error) {
     throw error;
   }
 
-  var bind = typeof port === 'string'
-    ? 'Pipe ' + port
-    : 'Port ' + port;
+  const bind = typeof port === 'string' ? `Pipe ${port}` : `Port ${port}`;
 
   // handle specific listen errors with friendly messages
   switch (error.code) {
     case 'EACCES':
-      console.error(bind + ' requires elevated privileges');
+      console.error(`${bind} requires elevated privileges`);
       process.exit(1);
       break;
     case 'EADDRINUSE':
-      console.error(bind + ' is already in use');
+      console.error(`${bind} is already in use`);
       process.exit(1);
       break;
     default:
@@ -85,10 +80,8 @@ function onError(error) {
  */
 
 function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string'
-    ? 'pipe ' + addr
-    : 'port ' + addr.port;
-  console.log("Server up listen " + addr.port)
-  debug('Listening on ' + bind);
+  const addr = server.address();
+  const bind = typeof addr === 'string' ? `pipe ${addr}` : `port ${addr.port}`;
+  console.log(`Server listening on ${bind}`);
+  debug(`Listening on ${bind}`);
 }

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -1,13 +1,18 @@
-const index =  function(req, res, next) {
-    const botType = process.env.BOT_TYPE;
-    const botID = process.env.BOT_ID;
-    
-    res.render('index', { 
-        title: `Lydia ${botType} ${botID}`
-    });
-    
+'use strict';
+
+function index(req, res) {
+  const botType = process.env.BOT_TYPE || 'Lydia';
+  const botID = process.env.BOT_ID || null;
+
+  res.json({
+    ok: true,
+    service: 'Lydia Bot',
+    botType,
+    botId: botID,
+    uptimeSeconds: process.uptime()
+  });
 }
 
 module.exports = {
-    index
-}
+  index
+};

--- a/controllers/manage.js
+++ b/controllers/manage.js
@@ -1,10 +1,168 @@
-const getGRCode =  function(req, res, next) {    
-    const qrcode = global.lydiabot.generatedQRCode;
-    res.render('qrcode', { 
-        qrcode: `${qrcode}`
+'use strict';
+
+const createError = require('http-errors');
+const QRCode = require('qrcode');
+
+const { sessionManager, errors } = require('../lib/session-manager');
+
+const { SessionAlreadyExistsError } = errors;
+
+const isDockerMode = /^true$/i.test(String(process.env.IS_DOCKER_MODE || 'false').trim());
+
+function buildSessionPayload(entry) {
+  if (!entry) {
+    return null;
+  }
+
+  return {
+    companyId: entry.companyId,
+    peopleId: entry.peopleId,
+    status: entry.status,
+    hasQr: Boolean(entry.lastQr),
+    lastQrAt: entry.lastQr?.ts || null,
+    readyInfo: entry.readyInfo || null,
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt,
+    lastError: entry.lastError || null,
+    disconnectReason: entry.disconnectReason || null,
+    state: entry.state || null
+  };
+}
+
+function getIdentifiers(req) {
+  const { companyId, peopleId } = req.params;
+  if (!companyId || !peopleId) {
+    throw createError(400, 'Both companyId and peopleId must be provided');
+  }
+
+  return { companyId, peopleId };
+}
+
+async function startInstance(req, res, next) {
+  try {
+    const { companyId, peopleId } = getIdentifiers(req);
+
+    const existing = sessionManager.getSession(companyId, peopleId);
+    if (existing) {
+      throw new SessionAlreadyExistsError(companyId, peopleId);
+    }
+
+    const entry = await sessionManager.startSession(companyId, peopleId);
+
+    return res.status(201).json({
+      message: 'Session starting',
+      session: buildSessionPayload(entry)
     });
+  } catch (error) {
+    if (error instanceof SessionAlreadyExistsError || error.code === 'SESSION_EXISTS') {
+      return next(createError(409, error.message));
+    }
+
+    return next(error);
+  }
+}
+
+function getInstanceStatus(req, res, next) {
+  try {
+    const { companyId, peopleId } = getIdentifiers(req);
+    const entry = sessionManager.getSession(companyId, peopleId);
+
+    if (!entry) {
+      return next(createError(404, 'Session not found'));
+    }
+
+    return res.json({
+      session: buildSessionPayload(entry)
+    });
+  } catch (error) {
+    return next(error);
+  }
+}
+
+async function getInstanceQr(req, res, next) {
+  try {
+    const { companyId, peopleId } = getIdentifiers(req);
+    const entry = sessionManager.getSession(companyId, peopleId);
+
+    if (!entry) {
+      return next(createError(404, 'Session not found'));
+    }
+
+    if (!entry.lastQr || !entry.lastQr.raw) {
+      return next(createError(404, 'QR code not yet generated'));
+    }
+
+    const preferredType = req.accepts(['image/png', 'image/svg+xml']) || 'image/png';
+
+    res.set('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
+    res.set('Pragma', 'no-cache');
+
+    if (preferredType === 'image/svg+xml') {
+      const svg = await QRCode.toString(entry.lastQr.raw, { type: 'svg', margin: 1 });
+      res.type('image/svg+xml');
+      return res.send(svg);
+    }
+
+    if (preferredType !== 'image/png') {
+      return next(createError(406, 'Unsupported media type requested'));
+    }
+
+    const pngBuffer = await QRCode.toBuffer(entry.lastQr.raw, { type: 'png', margin: 1, scale: 8 });
+    res.type('image/png');
+    return res.send(pngBuffer);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+async function restartInstance(req, res, next) {
+  try {
+    const { companyId, peopleId } = getIdentifiers(req);
+
+    const hadExisting = await sessionManager.destroySession(companyId, peopleId);
+
+    if (isDockerMode) {
+      res.status(202).json({
+        message: 'Restart acknowledged; container will exit to allow fresh provisioning',
+        companyId,
+        peopleId,
+        hadExisting,
+        willExit: true
+      });
+
+      setImmediate(() => {
+        try {
+          process.kill(process.pid, 'SIGTERM');
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to terminate process after restart request:', err);
+        }
+      });
+
+      return;
+    }
+
+    const entry = await sessionManager.startSession(companyId, peopleId);
+
+    return res.status(202).json({
+      message: 'Session restarting',
+      companyId,
+      peopleId,
+      hadExisting,
+      session: buildSessionPayload(entry)
+    });
+  } catch (error) {
+    if (error instanceof SessionAlreadyExistsError || error.code === 'SESSION_EXISTS') {
+      return next(createError(409, error.message));
+    }
+
+    return next(error);
+  }
 }
 
 module.exports = {
-    getGRCode
-}
+  startInstance,
+  getInstanceStatus,
+  getInstanceQr,
+  restartInstance
+};

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -1,0 +1,356 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { Client, LocalAuth } = require('whatsapp-web.js');
+const qrcodeTerminal = require('qrcode-terminal');
+
+const DEFAULT_PUPPETEER_ARGS = ['--no-sandbox', '--disable-setuid-sandbox'];
+const REMOTE_VERSION_BASE = 'https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html';
+
+function toBool(value, defaultValue = false) {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) {
+    return defaultValue;
+  }
+
+  return ['1', 'true', 'yes', 'y', 'on'].includes(normalized);
+}
+
+function parseArgs(value) {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => String(entry).trim())
+      .filter(Boolean);
+  }
+
+  return String(value)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function sanitizeSegment(value) {
+  const stringValue = value === undefined || value === null ? '' : String(value);
+  const trimmed = stringValue.trim();
+  if (!trimmed) {
+    return 'default';
+  }
+  return trimmed.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+class SessionError extends Error {
+  constructor(message, code, meta = {}) {
+    super(message);
+    this.name = 'SessionError';
+    this.code = code;
+    Object.assign(this, meta);
+  }
+}
+
+class SessionAlreadyExistsError extends SessionError {
+  constructor(companyId, peopleId) {
+    super(
+      `Session already exists for company ${companyId} and people ${peopleId}`,
+      'SESSION_EXISTS',
+      { companyId, peopleId }
+    );
+    this.name = 'SessionAlreadyExistsError';
+  }
+}
+
+class SessionNotFoundError extends SessionError {
+  constructor(companyId, peopleId) {
+    super(
+      `Session not found for company ${companyId} and people ${peopleId}`,
+      'SESSION_NOT_FOUND',
+      { companyId, peopleId }
+    );
+    this.name = 'SessionNotFoundError';
+  }
+}
+
+class SessionManager {
+  constructor(options = {}) {
+    this.instances = new Map();
+    this.logger = options.logger || console;
+
+    const rootDir = options.rootPath
+      ? path.resolve(options.rootPath)
+      : options.baseDir
+      ? path.resolve(options.baseDir)
+      : process.env.DATA_ROOT
+      ? path.resolve(process.env.DATA_ROOT)
+      : path.join(global.rootPath || process.cwd(), 'cache');
+
+    this.baseDir = rootDir;
+    this.authDir = options.authDir || path.join(rootDir, '.wwebjs_auth');
+    this.cacheDir = options.cacheDir || path.join(rootDir, '.wwebjs_cache');
+
+    this.webVersion = options.webVersion || process.env.WWebVersion || '';
+
+    const envArgs = parseArgs(process.env.PUPPETEER_ARGS);
+    const providedArgs = options.puppeteerArgs ? parseArgs(options.puppeteerArgs) : [];
+    this.puppeteerArgs = providedArgs.length ? providedArgs : envArgs;
+
+    if (!this.puppeteerArgs.length) {
+      this.puppeteerArgs = [...DEFAULT_PUPPETEER_ARGS];
+    }
+
+    this.headless = options.headless !== undefined
+      ? !!options.headless
+      : toBool(process.env.HEADLESS, true);
+
+    this.takeoverOnConflict = options.takeoverOnConflict !== undefined
+      ? !!options.takeoverOnConflict
+      : true;
+
+    this.takeoverTimeoutMs = options.takeoverTimeoutMs ?? 60_000;
+
+    this._fs = fs.promises;
+    this._baseDirsReady = false;
+  }
+
+  get loggerAvailable() {
+    return Boolean(this.logger);
+  }
+
+  _log(message, level = 'info') {
+    const timestamp = new Date().toISOString();
+    const formatted = `[${timestamp}] ${message}`;
+    if (!this.logger) {
+      return;
+    }
+
+    if (typeof this.logger[level] === 'function') {
+      this.logger[level](formatted);
+      return;
+    }
+
+    if (typeof this.logger.log === 'function') {
+      this.logger.log(formatted);
+      return;
+    }
+
+    // Fallback to console
+    if (level === 'error') {
+      console.error(formatted);
+    } else {
+      console.log(formatted);
+    }
+  }
+
+  _getKeyParts(companyId, peopleId) {
+    const companySegment = sanitizeSegment(companyId);
+    const peopleSegment = sanitizeSegment(peopleId);
+    const key = `${companySegment}:${peopleSegment}`;
+
+    const sessionDir = path.join(this.authDir, companySegment, peopleSegment);
+    const cacheDir = path.join(this.cacheDir, companySegment, peopleSegment);
+
+    return {
+      key,
+      companySegment,
+      peopleSegment,
+      sessionDir,
+      cacheDir
+    };
+  }
+
+  async _ensureBaseDirs() {
+    if (this._baseDirsReady) {
+      return;
+    }
+
+    await this._fs.mkdir(this.baseDir, { recursive: true });
+    await this._fs.mkdir(this.authDir, { recursive: true });
+    await this._fs.mkdir(this.cacheDir, { recursive: true });
+
+    this._baseDirsReady = true;
+  }
+
+  _setStatus(entry, status) {
+    entry.status = status;
+    entry.updatedAt = new Date().toISOString();
+  }
+
+  _attachClientEvents(entry, client) {
+    const { key } = entry;
+
+    client.on('qr', (qr) => {
+      this._setStatus(entry, 'qr');
+      entry.lastQr = {
+        raw: qr,
+        ts: new Date().toISOString()
+      };
+
+      try {
+        qrcodeTerminal.generate(qr, { small: true });
+      } catch (err) {
+        this._log(`Failed to render QR code in terminal for ${key}: ${err.message}`, 'error');
+      }
+
+      this._log(`QR generated for session ${key}`);
+    });
+
+    client.on('authenticated', () => {
+      this._setStatus(entry, 'authenticated');
+      this._log(`Session ${key} authenticated`);
+    });
+
+    client.on('ready', () => {
+      this._setStatus(entry, 'ready');
+      entry.readyInfo = {
+        wid: client.info?.wid?.user || null,
+        pushname: client.info?.pushname || null,
+        ts: new Date().toISOString()
+      };
+      this._log(`Session ${key} ready`);
+    });
+
+    client.on('auth_failure', (message) => {
+      this._setStatus(entry, 'failed');
+      entry.lastError = message;
+      this._log(`Authentication failed for session ${key}: ${message}`, 'error');
+    });
+
+    client.on('disconnected', (reason) => {
+      this._setStatus(entry, 'disconnected');
+      entry.disconnectReason = reason;
+      this._log(`Session ${key} disconnected: ${reason}`);
+    });
+
+    client.on('change_state', (state) => {
+      entry.state = state;
+      this._log(`Session ${key} state changed to ${state}`);
+    });
+  }
+
+  async startSession(companyId, peopleId) {
+    const { key, companySegment, peopleSegment, sessionDir, cacheDir } = this._getKeyParts(companyId, peopleId);
+
+    if (this.instances.has(key)) {
+      throw new SessionAlreadyExistsError(companyId, peopleId);
+    }
+
+    await this._ensureBaseDirs();
+    await this._fs.mkdir(sessionDir, { recursive: true });
+    await this._fs.mkdir(cacheDir, { recursive: true });
+
+    const entry = {
+      key,
+      companyId,
+      peopleId,
+      sanitizedCompanyId: companySegment,
+      sanitizedPeopleId: peopleSegment,
+      sessionDir,
+      cacheDir,
+      status: 'starting',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      lastQr: null,
+      readyInfo: null,
+      lastError: null,
+      disconnectReason: null,
+      state: null,
+      client: null
+    };
+
+    const authStrategy = new LocalAuth({
+      dataPath: sessionDir,
+      clientId: key
+    });
+
+    const webVersionCache = this.webVersion
+      ? {
+          type: 'remote',
+          remotePath: `${REMOTE_VERSION_BASE}/${this.webVersion}.html`
+        }
+      : {
+          type: 'local',
+          path: cacheDir
+        };
+
+    const client = new Client({
+      authStrategy,
+      webVersionCache,
+      takeoverOnConflict: this.takeoverOnConflict,
+      takeoverTimeoutMs: this.takeoverTimeoutMs,
+      puppeteer: {
+        headless: this.headless,
+        args: [...this.puppeteerArgs]
+      }
+    });
+
+    entry.client = client;
+    this._attachClientEvents(entry, client);
+
+    client.initialize().catch((err) => {
+      this._setStatus(entry, 'failed');
+      entry.lastError = err?.message || 'Unknown initialization error';
+      this._log(`Initialization failed for session ${key}: ${err.message}`, 'error');
+    });
+
+    this.instances.set(key, entry);
+    this._log(`Session ${key} starting`);
+    return entry;
+  }
+
+  getSession(companyId, peopleId) {
+    const { key } = this._getKeyParts(companyId, peopleId);
+    return this.instances.get(key) || null;
+  }
+
+  listSessions() {
+    return Array.from(this.instances.values());
+  }
+
+  async destroySession(companyId, peopleId) {
+    const { key } = this._getKeyParts(companyId, peopleId);
+    const entry = this.instances.get(key);
+    if (!entry) {
+      return false;
+    }
+
+    if (entry.client) {
+      try {
+        await entry.client.destroy();
+      } catch (err) {
+        this._log(`Failed to destroy client for session ${key}: ${err.message}`, 'error');
+      }
+    }
+
+    this.instances.delete(key);
+    this._log(`Session ${key} destroyed`);
+    return true;
+  }
+
+  async restartSession(companyId, peopleId) {
+    await this.destroySession(companyId, peopleId);
+    return this.startSession(companyId, peopleId);
+  }
+}
+
+const sessionManager = new SessionManager();
+
+module.exports = {
+  sessionManager,
+  SessionManager,
+  errors: {
+    SessionError,
+    SessionAlreadyExistsError,
+    SessionNotFoundError
+  }
+};

--- a/routes/manage.js
+++ b/routes/manage.js
@@ -1,9 +1,18 @@
-var express = require('express');
-var router = express.Router();
+'use strict';
 
-const {getGRCode} = require('../controllers/manage.js');
+const express = require('express');
+const router = express.Router();
 
-/* GET qrcode. */
-router.get('/qrcode', getGRCode);
+const {
+  startInstance,
+  getInstanceStatus,
+  getInstanceQr,
+  restartInstance
+} = require('../controllers/manage');
+
+router.post('/instances/:companyId/:peopleId', startInstance);
+router.get('/instances/:companyId/:peopleId/status', getInstanceStatus);
+router.get('/instances/:companyId/:peopleId/qr', getInstanceQr);
+router.post('/instances/:companyId/:peopleId/restart', restartInstance);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add a session manager for provisioning and tracking WhatsApp client instances
- replace the manage routes/controllers with JSON APIs for start, status, QR, and restart operations
- update the Express bootstrap to drop the Pug view layer and return structured JSON errors

## Testing
- node bin/www *(manually stopped)*

------
https://chatgpt.com/codex/tasks/task_b_68d19514eee08332b91b1a04cd19efdc