### PR TITLE
Implement manage session POST handler

### DIFF
--- a/controllers/manage.js
+++ b/controllers/manage.js
@@ -9,6 +9,28 @@ function buildStatusMessage(message) {
     };
 }
 
+function parseBoolean(value, defaultValue = false) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+
+        if (!normalized) {
+            return defaultValue;
+        }
+
+        return ['1', 'true', 'yes', 'on', 'y'].includes(normalized);
+    }
+
+    return defaultValue;
+}
+
 const getGRCode = function (req, res, next) {
     const { companyId, peopleId } = req.query;
 
@@ -47,6 +69,125 @@ const getGRCode = function (req, res, next) {
     }
 };
 
+const manageSession = async function (req, res, next) {
+    const {
+        action = 'status',
+        companyId,
+        peopleId,
+        wipe,
+        allowFallback
+    } = req.body || {};
+
+    const normalizedAction = String(action || 'status').trim().toLowerCase();
+
+    try {
+        switch (normalizedAction) {
+            case 'ensure':
+            case 'start':
+            case 'create': {
+                if (!companyId || !peopleId) {
+                    res.status(400);
+                    return res.json({
+                        status: 'error',
+                        message: 'Body parameters "companyId" and "peopleId" are required to start a session.'
+                    });
+                }
+
+                sessionManager.ensureSession(companyId, peopleId);
+                const status = sessionManager.getStatus(companyId, peopleId);
+
+                return res.json({
+                    status: 'success',
+                    action: 'ensure',
+                    session: status
+                });
+            }
+            case 'restart': {
+                if (!companyId || !peopleId) {
+                    res.status(400);
+                    return res.json({
+                        status: 'error',
+                        message: 'Body parameters "companyId" and "peopleId" are required to restart a session.'
+                    });
+                }
+
+                const shouldWipe = parseBoolean(wipe);
+                await sessionManager.restartSession(companyId, peopleId, { wipe: shouldWipe });
+                const status = sessionManager.getStatus(companyId, peopleId);
+
+                return res.json({
+                    status: 'success',
+                    action: 'restart',
+                    session: status
+                });
+            }
+            case 'destroy':
+            case 'stop': {
+                const shouldWipe = parseBoolean(wipe);
+                const fallbackAllowed = typeof allowFallback === 'undefined'
+                    ? true
+                    : parseBoolean(allowFallback, true);
+
+                if ((!companyId || !peopleId) && !fallbackAllowed) {
+                    res.status(400);
+                    return res.json({
+                        status: 'error',
+                        message: 'Body parameters "companyId" and "peopleId" are required to destroy a session when fallback is disabled.'
+                    });
+                }
+
+                const destroyed = await sessionManager.destroySession(companyId, peopleId, {
+                    wipe: shouldWipe,
+                    allowFallback: fallbackAllowed
+                });
+
+                if (!destroyed) {
+                    res.status(404);
+                    return res.json({
+                        status: 'error',
+                        message: 'Session not found.'
+                    });
+                }
+
+                return res.json({
+                    status: 'success',
+                    action: 'destroy'
+                });
+            }
+            case 'status':
+            case 'get':
+            case 'info':
+            case '': {
+                const status = sessionManager.getStatus(companyId, peopleId);
+
+                if (status === null) {
+                    res.status(404);
+                    return res.json({
+                        status: 'error',
+                        message: 'Session not found.'
+                    });
+                }
+
+                return res.json({
+                    status: 'success',
+                    action: 'status',
+                    session: status
+                });
+            }
+            default: {
+                res.status(400);
+                return res.json({
+                    status: 'error',
+                    message: `Unsupported action "${action}".`
+                });
+            }
+        }
+    } catch (error) {
+        return next(error);
+    }
+};
+
 module.exports = {
-    getGRCode
+    getGRCode,
+    manageSession
 };

--- a/routes/manage.js
+++ b/routes/manage.js
@@ -1,9 +1,12 @@
 var express = require('express');
 var router = express.Router();
 
-const {getGRCode} = require('../controllers/manage.js');
+const { getGRCode, manageSession } = require('../controllers/manage.js');
 
 /* GET qrcode. */
 router.get('/qrcode', getGRCode);
+
+/* POST session management. */
+router.post('/session', manageSession);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add a boolean parsing helper and a `manageSession` controller to handle session lifecycle actions
- wire up the `/manage/session` POST route to the new controller so Express receives a real callback

## Testing
- npm install *(fails: Chromium download blocked in container, preventing dependency install)*

------
https://chatgpt.com/codex/tasks/task_b_68d19d8938e08332aa99e9ea8679e4c2