### PR TITLE
Wait for QR on start and surface browser in dev

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,10 @@
 {
-    "ignore": ["**/*.test.ts", "**/*.spec.ts", "node_modules"],
-    "watch": ["*"],
-    "exec": "npm start",
-    "ext": "*"
+  "ignore": ["**/*.test.ts", "**/*.spec.ts", "node_modules"],
+  "watch": ["*"],
+  "exec": "npm start",
+  "ext": "*",
+  "env": {
+    "NODE_ENV": "development",
+    "HEADLESS": "false"
   }
+}


### PR DESCRIPTION
## Summary
- make the POST /instance/start flow block until a QR code is available (or timeout), matching the restart experience and reporting timeout metadata
- reuse the new QR wait result inside the restart route so both endpoints return status, ready info, QR data, and timeout info
- default puppeteer to a visible browser when running `npm run dev` by wiring NODE_ENV/HEADLESS in nodemon and opening devtools while keeping production headless

## Testing
- node -e "const router = require('./routes/instance'); console.log('routes loaded', typeof router);"

------
https://chatgpt.com/codex/tasks/task_b_68d29041233483329a357dfbe87b8956