### PR TITLE
Fix logger path resolution relative to project root

### DIFF
--- a/.env
+++ b/.env
@@ -7,5 +7,10 @@ HEADLESS=true
 # Pasta-raiz para sessions e cache do wwebjs
 DATA_ROOT=./cache
 
+# Arquivo de log persistente. Padrão: ${DATA_ROOT}/logs/instance.log
+# Caminhos relativos (DATA_ROOT/LOG_FILE) são resolvidos a partir da raiz do projeto.
+# Use `tail -f ./cache/logs/instance.log` (ou o caminho configurado) para acompanhar em tempo real.
+#LOG_FILE=./cache/logs/instance.log
+
 # Flags do Chromium (use estas em servidores Linux sem sandbox)
 PUPPETEER_ARGS=--no-sandbox,--disable-setuid-sandbox

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,216 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const { getLogFilePath } = require('./paths');
+
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024; // 10MB
+
+const logFilePath = getLogFilePath();
+
+const maxBytes = (() => {
+    const raw = process.env.LOG_FILE_MAX_SIZE;
+    if (!raw) {
+        return DEFAULT_MAX_BYTES;
+    }
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+    }
+    return DEFAULT_MAX_BYTES;
+})();
+
+const logDir = path.dirname(logFilePath);
+
+let announcedLogDestination = false;
+
+function announceLogDestination() {
+    if (announcedLogDestination) {
+        return;
+    }
+    announcedLogDestination = true;
+    const message = `[LOGGER] writing logs to ${logFilePath}`;
+    try {
+        process.stdout.write(`${message}\n`);
+    } catch (_) {}
+}
+
+function safeMkDir(dir) {
+    try {
+        fs.mkdirSync(dir, { recursive: true });
+    } catch (err) {
+        try {
+            process.stderr.write(`[LOGGER] Failed to create log directory ${dir}: ${err?.stack || err}\n`);
+        } catch (_) {}
+    }
+}
+
+function rotationSuffix() {
+    return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+let stream = null;
+let currentSize = 0;
+
+function closeStream() {
+    if (stream) {
+        try {
+            stream.end();
+        } catch (_) {}
+        stream = null;
+    }
+}
+
+function rotateActiveStream() {
+    closeStream();
+    try {
+        if (fs.existsSync(logFilePath)) {
+            const rotatedPath = `${logFilePath}.${rotationSuffix()}`;
+            fs.renameSync(logFilePath, rotatedPath);
+        }
+    } catch (err) {
+        try {
+            process.stderr.write(`[LOGGER] Failed to rotate log file ${logFilePath}: ${err?.stack || err}\n`);
+        } catch (_) {}
+    }
+    currentSize = 0;
+}
+
+function openStream() {
+    if (stream) {
+        return stream;
+    }
+
+    safeMkDir(logDir);
+
+    try {
+        if (fs.existsSync(logFilePath)) {
+            const stats = fs.statSync(logFilePath);
+            if (stats.size >= maxBytes) {
+                rotateActiveStream();
+            } else {
+                currentSize = stats.size;
+            }
+        } else {
+            currentSize = 0;
+        }
+    } catch (err) {
+        currentSize = 0;
+        try {
+            process.stderr.write(`[LOGGER] Failed to inspect log file ${logFilePath}: ${err?.stack || err}\n`);
+        } catch (_) {}
+    }
+
+    try {
+        stream = fs.createWriteStream(logFilePath, { flags: 'a', encoding: 'utf8' });
+        announceLogDestination();
+        if (!currentSize) {
+            try {
+                if (fs.existsSync(logFilePath)) {
+                    const stats = fs.statSync(logFilePath);
+                    currentSize = stats.size;
+                }
+            } catch (_) {
+                currentSize = 0;
+            }
+        }
+    } catch (err) {
+        stream = null;
+        try {
+            process.stderr.write(`[LOGGER] Failed to open log file ${logFilePath}: ${err?.stack || err}\n`);
+        } catch (_) {}
+    }
+
+    return stream;
+}
+
+function ensureCapacity(bytesToWrite) {
+    if (!Number.isFinite(bytesToWrite) || bytesToWrite < 0) {
+        bytesToWrite = 0;
+    }
+
+    if (!stream) {
+        openStream();
+    }
+
+    if (!stream) {
+        return;
+    }
+
+    if (currentSize + bytesToWrite > maxBytes) {
+        rotateActiveStream();
+        openStream();
+    }
+}
+
+function writeToFile(line) {
+    const entry = `${line}\n`;
+    const bytes = Buffer.byteLength(entry, 'utf8');
+    ensureCapacity(bytes);
+    if (!stream) {
+        return;
+    }
+    try {
+        stream.write(entry);
+        currentSize += bytes;
+    } catch (err) {
+        try {
+            process.stderr.write(`[LOGGER] Failed to write to log file ${logFilePath}: ${err?.stack || err}\n`);
+        } catch (_) {}
+    }
+}
+
+function formatLine(level, args) {
+    const message = args.length ? util.format(...args) : '';
+    return `${new Date().toISOString()} [${level}] ${message}`.trimEnd();
+}
+
+function baseLog(level, ...args) {
+    const normalizedLevel = String(level || 'INFO').toUpperCase();
+    const line = formatLine(normalizedLevel, args);
+    const consoleMethod = normalizedLevel === 'ERROR'
+        ? console.error
+        : normalizedLevel === 'WARN'
+            ? console.warn
+            : console.log;
+
+    consoleMethod(line);
+    writeToFile(line);
+}
+
+function info(...args) {
+    baseLog('INFO', ...args);
+}
+
+function warn(...args) {
+    baseLog('WARN', ...args);
+}
+
+function error(...args) {
+    baseLog('ERROR', ...args);
+}
+
+function debug(...args) {
+    baseLog('DEBUG', ...args);
+}
+
+function log(...args) {
+    info(...args);
+}
+
+process.on('exit', () => {
+    closeStream();
+});
+
+openStream();
+
+module.exports = {
+    log,
+    info,
+    warn,
+    error,
+    debug,
+    logFilePath
+};

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const path = require('path');
+
+function resolveProjectRoot() {
+    if (global.rootPath && typeof global.rootPath === 'string') {
+        return path.resolve(global.rootPath);
+    }
+
+    const envRoot = process.env.PROJECT_ROOT;
+    if (envRoot && envRoot.trim().length > 0) {
+        return path.resolve(envRoot.trim());
+    }
+
+    return path.resolve(__dirname, '..');
+}
+
+const PROJECT_ROOT = resolveProjectRoot();
+
+function resolveFromProjectRoot(targetPath) {
+    if (!targetPath) {
+        return PROJECT_ROOT;
+    }
+
+    return path.isAbsolute(targetPath)
+        ? targetPath
+        : path.resolve(PROJECT_ROOT, targetPath);
+}
+
+function getDataRoot() {
+    const raw = process.env.DATA_ROOT;
+    if (raw && raw.trim().length > 0) {
+        return resolveFromProjectRoot(raw.trim());
+    }
+
+    return path.join(PROJECT_ROOT, 'cache');
+}
+
+function getLogFilePath() {
+    const raw = process.env.LOG_FILE;
+    if (raw && raw.trim().length > 0) {
+        return resolveFromProjectRoot(raw.trim());
+    }
+
+    return path.join(getDataRoot(), 'logs', 'instance.log');
+}
+
+module.exports = {
+    PROJECT_ROOT,
+    resolveFromProjectRoot,
+    getDataRoot,
+    getLogFilePath
+};

--- a/routes/instance.js
+++ b/routes/instance.js
@@ -7,6 +7,9 @@ const { Client, LocalAuth } = require('whatsapp-web.js');
 const QRCode = require('qrcode');
 const qrcodeTerm = require('qrcode-terminal');
 
+const logger = require('../lib/logger');
+const { getDataRoot } = require('../lib/paths');
+
 const router = express.Router();
 
 /* ==========================
@@ -20,7 +23,7 @@ const HEADLESS = (() => {
     }
     return NODE_ENV === 'development' ? false : true;
 })();
-const DATA_ROOT = process.env.DATA_ROOT || path.join(process.cwd(), 'cache');
+const DATA_ROOT = getDataRoot();
 const PUPPETEER_ARGS = (process.env.PUPPETEER_ARGS || '')
     .split(',')
     .map(s => s.trim())
@@ -116,7 +119,7 @@ async function migrateDirectoryIfNeeded(from, to) {
         await fs.mkdir(path.dirname(to), { recursive: true });
         await fs.rename(from, to);
     } catch (err) {
-        console.warn(`[WARN] Falha ao migrar diretório de ${from} para ${to}:`, err);
+        logger.warn(`[WARN] Falha ao migrar diretório de ${from} para ${to}:`, err);
     }
 }
 
@@ -148,7 +151,7 @@ async function ensureStorageConsistency(key, sanitizedKey) {
             await fs.rename(legacySessionFolder, sanitizedSessionFolder);
         }
     } catch (err) {
-        console.warn(`[WARN] Falha ao migrar sessão de ${legacySessionFolder} para ${sanitizedSessionFolder}:`, err);
+        logger.warn(`[WARN] Falha ao migrar sessão de ${legacySessionFolder} para ${sanitizedSessionFolder}:`, err);
     }
 }
 
@@ -183,7 +186,7 @@ async function waitForNewQr(entry, { timeoutMs = WAIT_FOR_QR_TIMEOUT_MS, pollEve
         : Math.max(5000, pollEveryMs * 20);
 
     if (!entry) {
-        console.log('[QR_WAIT] (no-entry) Skip wait: instance entry not created');
+        logger.info('[QR_WAIT] (no-entry) Skip wait: instance entry not created');
         return { qr: null, timedOut: false, status: 'not_created', logContext: null };
     }
 
@@ -191,7 +194,7 @@ async function waitForNewQr(entry, { timeoutMs = WAIT_FOR_QR_TIMEOUT_MS, pollEve
 
     if (entry.lastQR) {
         const contextId = `${key}:${Date.now()}`;
-        console.log(`[QR_WAIT] (${contextId}) Returning cached QR without waiting`);
+        logger.info(`[QR_WAIT] (${contextId}) Returning cached QR without waiting`);
         return { qr: entry.lastQR, timedOut: false, status: entry.status, logContext: contextId };
     }
 
@@ -202,18 +205,18 @@ async function waitForNewQr(entry, { timeoutMs = WAIT_FOR_QR_TIMEOUT_MS, pollEve
         const contextId = `${key}:${startedAt}`;
         let lastBeatAt = startedAt;
 
-        console.log(`[QR_WAIT] (${contextId}) Starting wait (status=${entry.status}, timeoutMs=${timeoutMs}, pollEveryMs=${pollEveryMs})`);
+        logger.info(`[QR_WAIT] (${contextId}) Starting wait (status=${entry.status}, timeoutMs=${timeoutMs}, pollEveryMs=${pollEveryMs})`);
 
         const finish = (qr, timedOut, reason) => {
             const elapsed = Date.now() - startedAt;
             if (reason === 'qr') {
-                console.log(`[QR_WAIT] (${contextId}) QR received after ${elapsed}ms (status=${entry.status})`);
+                logger.info(`[QR_WAIT] (${contextId}) QR received after ${elapsed}ms (status=${entry.status})`);
             } else if (reason === 'terminal') {
-                console.log(`[QR_WAIT] (${contextId}) Finished due to terminal status=${entry.status} after ${elapsed}ms`);
+                logger.info(`[QR_WAIT] (${contextId}) Finished due to terminal status=${entry.status} after ${elapsed}ms`);
             } else if (reason === 'timeout') {
-                console.log(`[QR_WAIT] (${contextId}) Timed out after ${elapsed}ms (lastStatus=${entry.status})`);
+                logger.warn(`[QR_WAIT] (${contextId}) Timed out after ${elapsed}ms (lastStatus=${entry.status})`);
             } else {
-                console.log(`[QR_WAIT] (${contextId}) Finished (reason=${reason}) after ${elapsed}ms (status=${entry.status})`);
+                logger.info(`[QR_WAIT] (${contextId}) Finished (reason=${reason}) after ${elapsed}ms (status=${entry.status})`);
             }
             resolve({ qr, timedOut, status: entry.status, logContext: contextId });
         };
@@ -230,7 +233,7 @@ async function waitForNewQr(entry, { timeoutMs = WAIT_FOR_QR_TIMEOUT_MS, pollEve
                 return finish(null, true, 'timeout');
             }
             if (now - lastBeatAt >= beatEveryMs) {
-                console.log(`[QR_WAIT] (${contextId}) Still waiting... elapsed=${now - startedAt}ms status=${entry.status}`);
+                logger.info(`[QR_WAIT] (${contextId}) Still waiting... elapsed=${now - startedAt}ms status=${entry.status}`);
                 lastBeatAt = now;
             }
             setTimeout(check, pollEveryMs);
@@ -270,7 +273,7 @@ async function ensureInstance(companyId, peopleId, opts = {}) {
             } catch (_) {}
             instances.delete(key);
         } else {
-            console.log(`[INSTANCE] Reusing existing instance for key=${key} (status=${entry.status})`);
+            logger.info(`[INSTANCE] Reusing existing instance for key=${key} (status=${entry.status})`);
             // já existe e não queremos reiniciar: apenas retorna
             return instances.get(key);
         }
@@ -282,7 +285,7 @@ async function ensureInstance(companyId, peopleId, opts = {}) {
 
     await ensureStorageConsistency(key, sanitizedKey);
 
-    console.log(`[INSTANCE] Creating client for key=${key} companyId=${companyId} peopleId=${peopleId} forceRestart=${forceRestart} clientId=${sanitizedKey} sessionPath=${sessionPath} cachePath=${cachePath}`);
+    logger.info(`[INSTANCE] Creating client for key=${key} companyId=${companyId} peopleId=${peopleId} forceRestart=${forceRestart} clientId=${sanitizedKey} sessionPath=${sessionPath} cachePath=${cachePath}`);
 
     // Cria entry inicial
     const entry = {
@@ -335,12 +338,12 @@ async function ensureInstance(companyId, peopleId, opts = {}) {
 
         // opcional: mostrar no terminal
         qrcodeTerm.generate(qr, { small: true });
-        console.log(`[QR] ${key} @ ${ts}`);
+        logger.info(`[QR] ${key} @ ${ts}`);
     });
 
     client.on('authenticated', () => {
         entry.status = 'authenticated';
-        console.log(`[AUTH] ${key} autenticado…`);
+        logger.info(`[AUTH] ${key} autenticado…`);
     });
 
     client.on('ready', async () => {
@@ -348,26 +351,26 @@ async function ensureInstance(companyId, peopleId, opts = {}) {
         const wid = client.info?.wid?.user || null;
         const pushname = client.info?.pushname || null;
         entry.readyInfo = { wid, pushname, ts: new Date().toISOString() };
-        console.log(`[READY] ${key} OK - WID ${wid}`);
+        logger.info(`[READY] ${key} OK - WID ${wid}`);
     });
 
     client.on('auth_failure', (m) => {
         entry.status = 'failed';
-        console.log(`[AUTH_FAIL] ${key} - ${m}`);
+        logger.warn(`[AUTH_FAIL] ${key} - ${m}`);
     });
 
     client.on('disconnected', (r) => {
         entry.status = 'disconnected';
-        console.log(`[DISCONNECTED] ${key} - reason: ${r}`);
+        logger.warn(`[DISCONNECTED] ${key} - reason: ${r}`);
     });
 
     entry.client = client;
 
     // Inicia
-    console.log(`[INSTANCE] Initializing client for key=${key} companyId=${companyId} peopleId=${peopleId}`);
+    logger.info(`[INSTANCE] Initializing client for key=${key} companyId=${companyId} peopleId=${peopleId}`);
     client.initialize().catch((e) => {
         entry.status = 'failed';
-        console.error(`[INIT_ERROR] ${key}`, e);
+        logger.error(`[INIT_ERROR] ${key}`, e);
     });
 
     return entry;

--- a/server.js
+++ b/server.js
@@ -8,6 +8,8 @@ const { Client, LocalAuth } = require('whatsapp-web.js');
 const QRCode = require('qrcode');
 const qrcodeTerm = require('qrcode-terminal');
 
+const { getDataRoot } = require('./lib/paths');
+
 const app = express();
 app.use(express.json({ limit: '2mb' }));
 
@@ -16,7 +18,7 @@ app.use(express.json({ limit: '2mb' }));
    ========================== */
 const PORT = parseInt(process.env.PORT || '8081', 10);
 const HEADLESS = String(process.env.HEADLESS || 'true').toLowerCase() === 'true';
-const DATA_ROOT = process.env.DATA_ROOT || path.join(__dirname, 'data'); // onde salvamos sessões
+const DATA_ROOT = getDataRoot(); // onde salvamos sessões
 const PUPPETEER_ARGS = (process.env.PUPPETEER_ARGS || '')
   .split(',')
   .map(s => s.trim())


### PR DESCRIPTION
## Summary
- add a lib/paths helper so DATA_ROOT/LOG_FILE resolve relative to the project root even when the process cwd differs
- update the shared logger and instance/server entrypoints to rely on the helper and announce the resolved log destination
- document in the env sample that relative paths are project-root relative for easier troubleshooting

## Testing
- node -e "const logger = require('./lib/logger'); logger.info('Logger bootstrap smoke test');"

------
https://chatgpt.com/codex/tasks/task_b_68d2aa29e398833295523ddd7b31240b